### PR TITLE
Changed the pattern to render file types in color.

### DIFF
--- a/print_tools/get_child_item_size.py
+++ b/print_tools/get_child_item_size.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
-https://blog.csdn.net/zhangyixin_618/article/details/89526717
+An implementation of
+`ls -lh` (GNU Coreutils) and `Get-ChildItem` (PowerShell)
+in Python.
 
-https://www.cnblogs.com/unclemac/p/12783387.html
+References:
+
+1. https://blog.csdn.net/zhangyixin_618/article/details/89526717
+2. https://www.cnblogs.com/unclemac/p/12783387.html
 """
 
 import argparse
@@ -30,9 +35,32 @@ def get_child_item_size(folder_path: str,
     Get the size of each child item in the input directory
     in a human-readable format.
     """
+
+    def set_order_of_items(item: Path) -> tuple:
+        """
+        Set the order of sorting.
+
+        Parameters
+        ----------
+        item: Path
+            The path to the file or directory.
+
+        Returns
+        -------
+        tuple:
+            A tuple containing the file status (file or directory),
+            lower case file name,
+            and the file name with alphanumeric characters removed.
+        """
+        return (
+            item.is_file(),
+            item.name.lower(),
+            re.sub("[A-Za-z0-9]+", "", item.name)
+        )
+
     if Path(folder_path).is_dir():
         name_and_size = {}
-        for child_item in sorted(Path(folder_path).iterdir(), key=lambda x: re.sub('[^A-Za-z0-9]+', '', x.name)):
+        for child_item in sorted(Path(folder_path).iterdir(), key=set_order_of_items):
             file_name = Path(child_item).name
             file_size = Path(child_item).stat().st_size
             if human_readable:
@@ -44,10 +72,12 @@ def get_child_item_size(folder_path: str,
                     {file_name: str(file_size)}
                 )
         return name_and_size
+
     elif not Path(folder_path).is_dir():
         raise ValueError(
             "The input path is not a directory."
         )
+
     return None
 
 
@@ -67,7 +97,7 @@ def format_size(file_size: Union[int, float]) -> str:
 
 def main() -> None:
     """
-    __doc__
+    The main function.
     """
     parser = argparse.ArgumentParser(
         prog=f"{Path(__file__).name}",
@@ -106,13 +136,22 @@ def main() -> None:
         )
     )
     parser.add_argument(
-        "-c",
-        "--color",
+        "-cd",
+        "--color_dir",
+        default="Blue",
+        type=str,
+        help=(
+            "Specify the color of the printed directories.\n"
+            "The default is: %(default)s"
+        )
+    )
+    parser.add_argument(
+        "-cf",
+        "--color_file",
         default="Default",
         type=str,
-        # choices=list(COLORS.keys()),
         help=(
-            "Specify the color of the printed files or directories.\n"
+            "Specify the color of the printed files.\n"
             "The default is: %(default)s"
         )
     )
@@ -121,30 +160,36 @@ def main() -> None:
         "--version",
         action="version",
         help="Print the version number of %(prog)s and exit.",
-        version="%(prog)s 1.0.4"
+        version="%(prog)s 2.0.1"
     )
 
     command_args = parser.parse_args()
 
     path_passed = command_args.path if command_args.path is not None else command_args.folder_path
-    size_of_child_item = get_child_item_size(
+    child_item_and_size = get_child_item_size(
         folder_path=path_passed,
         human_readable=True if command_args.human_readable == "yes" else False
     )
 
-    print("\n")
+    print("")
     print(
-        f"Directory: {Path(path_passed).absolute()}"
+        "Directory: "
+        f"{COLORS['Green']}{Path(path_passed).absolute()}{COLORS['Default']}"
     )
-    print("\n")
+    print("")
 
-    if size_of_child_item is not None:
+    if child_item_and_size is not None:
         print("Length  Name".rjust(16))
         print("------  ----".rjust(16))
-        for name, size in size_of_child_item.items():
-            color = COLORS[command_args.color.capitalize()]
-            print(f"{color}{size:>10}  {name}{COLORS['Default']}")
-        print("\n")
+        for name, size in child_item_and_size.items():
+            if Path(path_passed).joinpath(name).is_dir():
+                print(
+                    f"{size:>10} {COLORS[command_args.color_dir.capitalize()]}{name}{COLORS['Default']}"
+                )
+            elif Path(path_passed).joinpath(name).is_file():
+                print(
+                    f"{size:>10} {COLORS[command_args.color_file.capitalize()]}{name}{COLORS['Default']}"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Changed `lambda` to `set_order_of_items()` to set the order of sorting.
- Use `-cd` or `--color_dir` to specify the color of the printed directories; Use `-cf` or `--color_file` to specify the color of the printed files.
- Always show sizes of files and directories in `'Default'` color.